### PR TITLE
Fix extend-exclude list in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ extend-ignore = E203,E731
 extend-exclude =
     venv,
     .venv,
-    container/builds/*
+    container/builds/*,
     container/services/*
 max-line-length = 120
 per-file-ignores =


### PR DESCRIPTION
Add missing comma in flake8's `extend-exclude` list.